### PR TITLE
Add conversion to/from OCaml for boxed slice

### DIFF
--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -80,6 +80,13 @@ unsafe impl FromOCaml<OCamlBytes> for Vec<u8> {
     }
 }
 
+unsafe impl FromOCaml<OCamlBytes> for Box<[u8]> {
+    fn from_ocaml(v: OCaml<OCamlBytes>) -> Self {
+        let raw_bytes = v.as_bytes();
+        Box::from(raw_bytes)
+    }
+}
+
 unsafe impl FromOCaml<OCamlBytes> for String {
     fn from_ocaml(v: OCaml<OCamlBytes>) -> Self {
         unsafe { v.as_str_unchecked() }.to_owned()

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -136,6 +136,13 @@ unsafe impl ToOCaml<OCamlBytes> for Vec<u8> {
     }
 }
 
+unsafe impl ToOCaml<OCamlBytes> for Box<[u8]> {
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+        let slice: &[u8] = self;
+        slice.to_ocaml(cr)
+    }
+}
+
 unsafe impl<A, OCamlA> ToOCaml<OCamlA> for Box<A>
 where
     A: ToOCaml<OCamlA>,

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -143,6 +143,13 @@ unsafe impl ToOCaml<OCamlBytes> for Box<[u8]> {
     }
 }
 
+unsafe impl ToOCaml<Array1<u8>> for Box<[u8]> {
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Array1<u8>> {
+        let slice: &[u8] = self;
+        slice.to_ocaml(cr)
+    }
+}
+
 unsafe impl<A, OCamlA> ToOCaml<OCamlA> for Box<A>
 where
     A: ToOCaml<OCamlA>,


### PR DESCRIPTION
- Add implementation `{From,To}OCaml<OCamlBytes> for Box<[u8]>`
- Add `ToOCaml<Array1<u8>> for Box<[u8]>`. This converts a Rust boxed slice to an OCaml `bigstring`