### PR TITLE
Add support for generating bytecode-callable exported function wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for OCaml `Bigarray.Array1` values (PR #26 by @g2p)
+- Support for callable closure values with more automatic conversion between Rust and OCaml values (PR #44 and PR #45 by @sebastiencs)
+- Conversions for `<Box<[u8]>` (PR #47 by @sebastiencs)
+- Support for defining bytecode-callable wrappers for functions with `ocaml_export!` macro (PR #50)
 
 ## [0.8.8] - 2022-03-23
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -25,10 +25,7 @@ pub struct OCaml<'a, T: 'a> {
 
 impl<'a, T> Clone for OCaml<'a, T> {
     fn clone(&self) -> Self {
-        OCaml {
-            _marker: PhantomData,
-            raw: self.raw,
-        }
+        *self
     }
 }
 

--- a/testing/ocaml-caller/ocaml_rust_caller.ml
+++ b/testing/ocaml-caller/ocaml_rust_caller.ml
@@ -58,6 +58,9 @@ module Rust = struct
 
   external string_of_polymorphic_movement : movement_polymorphic -> string
     = "rust_string_of_polymorphic_movement"
+
+  external rust_rust_add_7ints : int -> int -> int -> int -> int -> int -> int -> int
+    = "rust_rust_add_7ints" "rust_rust_add_7ints_byte"
 end
 
 let test_twice () = Alcotest.(check int) "Multiply by 2" 20 (Rust.twice 10)
@@ -144,6 +147,11 @@ let test_interpret_polymorphic_movement () =
   Alcotest.(check (list string))
     "Interpret a polymorphic variant" expected result
 
+let test_byte_function () =
+  let expected = 1 + 2 + 3 + 4 + 5 + 6 + 7 in
+  let result = Rust.rust_rust_add_7ints 1 2 3 4 5 6 7 in
+  Alcotest.(check int) "Call a bytecode function" expected result
+
 (* Sleeps on the Rust thread releasing the OCaml runtime lock *)
 let test_blocking_section () =
   let before = Unix.gettimeofday () in
@@ -193,6 +201,7 @@ let () =
           test_case "Rust.string_of_movement" `Quick test_interpret_movement;
           test_case "Rust.string_of_polymorphic_movement" `Quick
             test_interpret_polymorphic_movement;
+          test_case "Rust.rust_rust_add_7ints" `Quick test_byte_function
         ] );
     ];
   Rust.tests_teardown ()

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -145,4 +145,24 @@ ocaml_export! {
         };
         s.to_ocaml(cr)
     }
+
+    fn rust_rust_add_7ints|rust_rust_add_7ints_byte(
+        cr,
+        int1: OCamlRef<OCamlInt>,
+        int2: OCamlRef<OCamlInt>,
+        int3: OCamlRef<OCamlInt>,
+        int4: OCamlRef<OCamlInt>,
+        int5: OCamlRef<OCamlInt>,
+        int6: OCamlRef<OCamlInt>,
+        int7: OCamlRef<OCamlInt>,
+    ) -> OCaml<OCamlInt> {
+        let int1: i64 = int1.to_rust(cr);
+        let int2: i64 = int2.to_rust(cr);
+        let int3: i64 = int3.to_rust(cr);
+        let int4: i64 = int4.to_rust(cr);
+        let int5: i64 = int5.to_rust(cr);
+        let int6: i64 = int6.to_rust(cr);
+        let int7: i64 = int7.to_rust(cr);
+        unsafe { OCaml::of_i64_unchecked(int1 + int2 + int3 + int4 + int5 + int6 + int7) }
+    }
 }


### PR DESCRIPTION
Solves #49 