### PR TITLE
Fix argument types in expansion of bytecode-callable functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Expansion of bytecode-callable functions (PR #53, reported and debugged by @mt-caret in #52).
+
 ## [0.9.1] - 2023-07-12
 
 ### Fixed

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1540,13 +1540,13 @@ macro_rules! expand_exported_byte_function {
         @return { $($rtyp:tt)* }
     } => {
         #[no_mangle]
-        pub extern "C" fn $byte_name(argv: &[$crate::RawOCaml], argn: isize) -> $crate::expand_exported_function_return!($($rtyp)*) {
+        pub extern "C" fn $byte_name(argv: *mut $crate::RawOCaml, argn: std::os::raw::c_int) -> $crate::expand_exported_function_return!($($rtyp)*) {
             let mut i = 0usize;
             $(
-                let $arg = argv[i];
+                let $arg = unsafe { core::ptr::read(argv.add(i)) };
                 i += 1;
             )+
-            debug_assert!(i == argn as usize);
+            debug_assert_eq!(i, argn as usize, "count of arguments read from argv matches argn");
             $name($($arg),*)
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1543,6 +1543,7 @@ macro_rules! expand_exported_byte_function {
         pub extern "C" fn $byte_name(argv: *mut $crate::RawOCaml, argn: std::os::raw::c_int) -> $crate::expand_exported_function_return!($($rtyp)*) {
             let mut i = 0usize;
             $(
+                #[allow(clippy::not_unsafe_ptr_arg_deref)]
                 let $arg = unsafe { core::ptr::read(argv.add(i)) };
                 i += 1;
             )+


### PR DESCRIPTION
Fixes #52