### PR TITLE
allow to_ocaml to takes owned self

### DIFF
--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -19,66 +19,102 @@ use crate::{
 };
 
 /// Implements conversion from Rust values into OCaml values.
-pub unsafe trait ToOCaml<T> {
+pub unsafe trait ToOCaml<T>: Sized {
     /// Convert to OCaml value. Return an already rooted value as [`BoxRoot`]`<T>`.
-    fn to_boxroot(&self, cr: &mut OCamlRuntime) -> BoxRoot<T> {
+    fn to_boxroot(self, cr: &mut OCamlRuntime) -> BoxRoot<T> {
         BoxRoot::new(self.to_ocaml(cr))
     }
 
     /// Convert to OCaml value.
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T>;
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T>;
 }
 
 unsafe impl<'root, T> ToOCaml<T> for OCamlRef<'root, T> {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T> {
         unsafe { OCaml::new(cr, self.get_raw()) }
     }
 }
 
 unsafe impl<T> ToOCaml<T> for BoxRoot<T> {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T> {
         self.get(cr)
     }
 }
 
 unsafe impl ToOCaml<()> for () {
-    fn to_ocaml(&self, _cr: &mut OCamlRuntime) -> OCaml<'static, ()> {
+    fn to_ocaml(self, _cr: &mut OCamlRuntime) -> OCaml<'static, ()> {
         OCaml::unit()
     }
 }
 
 unsafe impl ToOCaml<OCamlInt> for i64 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
         unsafe { OCaml::new(cr, ((self << 1) | 1i64) as RawOCaml) }
     }
 }
 
 unsafe impl ToOCaml<OCamlInt> for i32 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
-        (*self as i64).to_ocaml(cr)
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
+        (self as i64).to_ocaml(cr)
     }
 }
 
 unsafe impl ToOCaml<OCamlInt32> for i32 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt32> {
-        alloc_int32(cr, *self)
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt32> {
+        alloc_int32(cr, self)
     }
 }
 
 unsafe impl ToOCaml<OCamlInt64> for i64 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt64> {
-        alloc_int64(cr, *self)
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt64> {
+        alloc_int64(cr, self)
     }
 }
 
 unsafe impl ToOCaml<OCamlFloat> for f64 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlFloat> {
-        alloc_double(cr, *self)
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlFloat> {
+        alloc_double(cr, self)
     }
 }
 
 unsafe impl ToOCaml<bool> for bool {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, bool> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, bool> {
+        unsafe { OCaml::new(cr, if self { TRUE } else { FALSE }) }
+    }
+}
+
+unsafe impl ToOCaml<OCamlInt> for &i64 {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
+        unsafe { OCaml::new(cr, ((self << 1) | 1i64) as RawOCaml) }
+    }
+}
+
+unsafe impl ToOCaml<OCamlInt> for &i32 {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
+        (*self as i64).to_ocaml(cr)
+    }
+}
+
+unsafe impl ToOCaml<OCamlInt32> for &i32 {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt32> {
+        alloc_int32(cr, *self)
+    }
+}
+
+unsafe impl ToOCaml<OCamlInt64> for &i64 {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt64> {
+        alloc_int64(cr, *self)
+    }
+}
+
+unsafe impl ToOCaml<OCamlFloat> for &f64 {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlFloat> {
+        alloc_double(cr, *self)
+    }
+}
+
+unsafe impl ToOCaml<bool> for &bool {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, bool> {
         unsafe { OCaml::new(cr, if *self { TRUE } else { FALSE }) }
     }
 }
@@ -89,72 +125,70 @@ unsafe impl ToOCaml<bool> for bool {
 // conflict.
 
 unsafe impl ToOCaml<String> for &str {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
         alloc_string(cr, self)
     }
 }
 
 unsafe impl ToOCaml<OCamlBytes> for &str {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
         alloc_bytes(cr, self.as_bytes())
     }
 }
 
 unsafe impl ToOCaml<OCamlBytes> for &[u8] {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
         alloc_bytes(cr, self)
     }
 }
 
 unsafe impl ToOCaml<String> for &[u8] {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
         alloc_string(cr, unsafe { str::from_utf8_unchecked(self) })
     }
 }
 
 unsafe impl ToOCaml<String> for String {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
         self.as_str().to_ocaml(cr)
     }
 }
 
 unsafe impl ToOCaml<OCamlBytes> for String {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+        self.as_str().to_ocaml(cr)
+    }
+}
+
+unsafe impl ToOCaml<String> for &String {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+        self.as_str().to_ocaml(cr)
+    }
+}
+
+unsafe impl ToOCaml<OCamlBytes> for &String {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
         self.as_str().to_ocaml(cr)
     }
 }
 
 unsafe impl ToOCaml<String> for Vec<u8> {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
         self.as_slice().to_ocaml(cr)
     }
 }
 
 unsafe impl ToOCaml<OCamlBytes> for Vec<u8> {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
         self.as_slice().to_ocaml(cr)
     }
 }
 
-unsafe impl ToOCaml<OCamlBytes> for Box<[u8]> {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
-        let slice: &[u8] = self;
-        slice.to_ocaml(cr)
-    }
-}
-
-unsafe impl ToOCaml<Array1<u8>> for Box<[u8]> {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Array1<u8>> {
-        let slice: &[u8] = self;
-        slice.to_ocaml(cr)
-    }
-}
-
-unsafe impl<A, OCamlA> ToOCaml<OCamlA> for Box<A>
+unsafe impl<A, OCamlA> ToOCaml<OCamlA> for &Box<A>
 where
-    A: ToOCaml<OCamlA>,
+    for<'a> &'a A: ToOCaml<OCamlA>,
 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlA> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlA> {
         self.as_ref().to_ocaml(cr)
     }
 }
@@ -163,7 +197,7 @@ unsafe impl<A, OCamlA: 'static> ToOCaml<Option<OCamlA>> for Option<A>
 where
     A: ToOCaml<OCamlA>,
 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Option<OCamlA>> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Option<OCamlA>> {
         if let Some(value) = self {
             let ocaml_value = value.to_boxroot(cr);
             alloc_some(cr, &ocaml_value)
@@ -179,7 +213,7 @@ where
     A: ToOCaml<OCamlA>,
     Err: ToOCaml<OCamlErr>,
 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Result<OCamlA, OCamlErr>> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Result<OCamlA, OCamlErr>> {
         match self {
             Ok(value) => {
                 let ocaml_value = value.to_boxroot(cr);
@@ -193,11 +227,11 @@ where
     }
 }
 
-unsafe impl<A, OCamlA: 'static> ToOCaml<OCamlList<OCamlA>> for Vec<A>
+unsafe impl<A, OCamlA: 'static> ToOCaml<OCamlList<OCamlA>> for &Vec<A>
 where
-    A: ToOCaml<OCamlA>,
+    for<'a> &'a A: ToOCaml<OCamlA>,
 {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlList<OCamlA>> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlList<OCamlA>> {
         let mut result = BoxRoot::new(OCaml::nil());
         for elt in self.iter().rev() {
             let ov = elt.to_boxroot(cr);
@@ -216,7 +250,7 @@ macro_rules! tuple_to_ocaml {
         where
             $($t: ToOCaml<$ot>),+
         {
-            fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, ($($ot),+)> {
+            fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, ($($ot),+)> {
                 let len = $crate::count_fields!($($t)*);
 
                     let ocaml_tuple: BoxRoot<($($ot),+)> = BoxRoot::new(unsafe { alloc_tuple(cr, len) });
@@ -299,7 +333,7 @@ tuple_to_ocaml!(
 
 // This copies
 unsafe impl<A: BigarrayElt> ToOCaml<Array1<A>> for &[A] {
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Array1<A>> {
+    fn to_ocaml<'a>(self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Array1<A>> {
         alloc_bigarray1(cr, self)
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -587,8 +587,8 @@ macro_rules! impl_to_ocaml_record {
     ($rust_typ:ty => $ocaml_typ:ident {
         $($field:ident : $ocaml_field_typ:ty $(=> $conv_expr:expr)?),+ $(,)?
     }) => {
-        unsafe impl $crate::ToOCaml<$ocaml_typ> for $rust_typ {
-            fn to_ocaml<'a>(&self, cr: &'a mut $crate::OCamlRuntime) -> $crate::OCaml<'a, $ocaml_typ> {
+        unsafe impl $crate::ToOCaml<$ocaml_typ> for &$rust_typ {
+            fn to_ocaml<'a>(self, cr: &'a mut $crate::OCamlRuntime) -> $crate::OCaml<'a, $ocaml_typ> {
                 $crate::ocaml_alloc_record! {
                     cr, self {
                         $($field : $ocaml_field_typ $(=> $conv_expr)?),+
@@ -858,7 +858,7 @@ macro_rules! impl_to_ocaml_variant {
         $($t:tt)*
     }) => {
         unsafe impl $crate::ToOCaml<$ocaml_typ> for $rust_typ {
-            fn to_ocaml<'a>(&self, cr: &'a mut $crate::OCamlRuntime) -> $crate::OCaml<'a, $ocaml_typ> {
+            fn to_ocaml<'a>(self, cr: &'a mut $crate::OCamlRuntime) -> $crate::OCaml<'a, $ocaml_typ> {
                 $crate::ocaml_alloc_variant! {
                     cr, self => {
                         $($t)*
@@ -923,8 +923,8 @@ macro_rules! impl_to_ocaml_polymorphic_variant {
     ($rust_typ:ty => $ocaml_typ:ty {
         $($t:tt)*
     }) => {
-        unsafe impl $crate::ToOCaml<$ocaml_typ> for $rust_typ {
-            fn to_ocaml<'a>(&self, cr: &'a mut $crate::OCamlRuntime) -> $crate::OCaml<'a, $ocaml_typ> {
+        unsafe impl $crate::ToOCaml<$ocaml_typ> for &$rust_typ {
+            fn to_ocaml<'a>(self, cr: &'a mut $crate::OCamlRuntime) -> $crate::OCaml<'a, $ocaml_typ> {
                 $crate::ocaml_alloc_polymorphic_variant! {
                     cr, self => {
                         $($t)*

--- a/src/value.rs
+++ b/src/value.rs
@@ -530,10 +530,10 @@ impl<'a, 'b, OCamlValue> OCamlParam<'a, 'b, (), OCamlValue> for &'a OCamlRef<'b,
 
 impl<'a, 'b, RustValue, OCamlValue> OCamlParam<'a, 'b, RustValue, OCamlValue> for &RustValue
 where
-    RustValue: crate::ToOCaml<OCamlValue>,
+    for<'c> &'c RustValue: crate::ToOCaml<OCamlValue>,
 {
     fn to_rooted(self, cr: &mut OCamlRuntime) -> RefOrRooted<'a, 'b, OCamlValue> {
-        let boxroot = self.to_boxroot(cr);
+        let boxroot = crate::ToOCaml::to_boxroot(self, cr);
         RefOrRooted::Root(boxroot)
     }
 }


### PR DESCRIPTION
This is a rough proposal (with code!) to update `ToOCaml::to_ocaml` to take `self` instead of `&self`. It also changes many default implementations of `ToOCaml` to be implemented on `&SomeType` instead of `SomeType`. As far as I understand it:

* this usually won't affect the ergonomics of calling `to_ocaml`, since Rust will automatically take a reference of when calling a method on it.
* if you're implementing a generic function, and want to make sure you can convert just a reference of something into OCaml without giving up ownership, you can still add the type constraint `for <'a> &'a T: ToOCaml`
* i think this allows users to implement more efficient conversions in some cases --- for example, perhaps an owned String could be converted into a Bigarray without copying?