### PR TITLE
Float and Uniform array support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - run: opam install dune alcotest
+      - run: opam install dune alcotest base
       - name: Rust caller test
         run: cd testing/rust-caller; cargo test
       - name: Build OCaml caller

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 features = [ "without-ocamlopt" ]
 
 [dependencies]
-ocaml-sys = "0.22"
+ocaml-sys = "0.23"
 ocaml-boxroot-sys = "0.2"
 static_assertions = "1.1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,8 @@ pub use crate::error::OCamlException;
 pub use crate::memory::alloc_cons as cons;
 pub use crate::memory::OCamlRef;
 pub use crate::mlvalues::{
-    bigarray, DynBox, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml,
+    bigarray, DynBox, OCamlBytes, OCamlFloat, OCamlFloatArray, OCamlInt, OCamlInt32, OCamlInt64,
+    OCamlList, OCamlUniformArray, RawOCaml,
 };
 pub use crate::runtime::OCamlRuntime;
 pub use crate::value::OCaml;

--- a/src/mlvalues.rs
+++ b/src/mlvalues.rs
@@ -20,6 +20,20 @@ pub struct OCamlList<A> {
     _marker: PhantomData<A>,
 }
 
+/// [`OCaml`]`<OCamlUniformArray<T>>` is a reference to an OCaml array which is
+/// guaranteed to not contain unboxed floats. If OCaml was configured with
+/// `--disable-flat-float-array` this corresponds to regular `array`s, but if
+/// not, `Uniform_array.t` in the `base` library can be used instead.
+/// See [Lexifi's blog post on the topic](https://www.lexifi.com/blog/ocaml/about-unboxed-float-arrays/)
+/// for more details.
+pub struct OCamlUniformArray<A> {
+    _marker: PhantomData<A>,
+}
+
+/// [`OCaml`]`<OCamlFloatArray<T>>` is a reference to an OCaml `floatarray`
+/// which is an array containing `float`s in an unboxed form.
+pub struct OCamlFloatArray {}
+
 /// `OCaml<DynBox<T>>` is for passing a value of type `T` to OCaml
 ///
 /// To box a Rust value, use [`OCaml::box_value`][crate::OCaml::box_value].

--- a/src/mlvalues/tag.rs
+++ b/src/mlvalues/tag.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Viable Systems and TezEdge Contributors
 // SPDX-License-Identifier: MIT
 
-pub use ocaml_sys::{Tag, CLOSURE, NO_SCAN, STRING, TAG_CONS as CONS, TAG_SOME as SOME};
+pub use ocaml_sys::{
+    Tag, CLOSURE, DOUBLE_ARRAY, NO_SCAN, STRING, TAG_CONS as CONS, TAG_SOME as SOME,
+};
 
 pub const TAG_POLYMORPHIC_VARIANT: Tag = 0;
 pub const TAG_OK: Tag = 0;

--- a/src/value.rs
+++ b/src/value.rs
@@ -49,13 +49,18 @@ impl<'a, T> OCaml<'a, T> {
     }
 
     #[doc(hidden)]
+    pub unsafe fn size(&self) -> UIntnat {
+        wosize_val(self.raw)
+    }
+
+    #[doc(hidden)]
     pub unsafe fn field<F>(&self, i: UIntnat) -> OCaml<'a, F> {
         assert!(
             tag_val(self.raw) < tag::NO_SCAN,
             "unexpected OCaml value tag >= NO_SCAN"
         );
         assert!(
-            i < wosize_val(self.raw),
+            i < self.size(),
             "trying to access a field bigger than the OCaml block value"
         );
         OCaml {
@@ -71,7 +76,7 @@ impl<'a, T> OCaml<'a, T> {
 
     #[doc(hidden)]
     pub fn is_block_sized(&self, size: usize) -> bool {
-        self.is_block() && unsafe { wosize_val(self.raw) == size }
+        self.is_block() && unsafe { self.size() == size }
     }
 
     #[doc(hidden)]

--- a/testing/ocaml-caller/dune
+++ b/testing/ocaml-caller/dune
@@ -1,7 +1,8 @@
 (executables
  (names ocaml_rust_caller)
- (libraries alcotest callable_rust threads.posix))
+ (libraries alcotest base callable_rust threads.posix))
 
 (rule
- (alias  runtest)
- (action (run ./ocaml_rust_caller.exe)))
+ (alias runtest)
+ (action
+  (run ./ocaml_rust_caller.exe)))

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -3,7 +3,8 @@
 
 use ocaml_interop::{
     ocaml_export, ocaml_unpack_polymorphic_variant, ocaml_unpack_variant, OCaml, OCamlBytes,
-    OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRef, ToOCaml,
+    OCamlFloat, OCamlFloatArray, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRef,
+    OCamlUniformArray, ToOCaml,
 };
 use std::{thread, time};
 
@@ -68,6 +69,36 @@ ocaml_export! {
 
         for i in 0..vec.len() {
             vec[i] += 1;
+        }
+
+        vec.to_ocaml(cr)
+    }
+
+    fn rust_increment_ints_uniform_array(cr, ints: OCamlRef<OCamlUniformArray<OCamlInt>>) -> OCaml<OCamlUniformArray<OCamlInt>> {
+        let mut vec: Vec<i64> = ints.to_rust(cr);
+
+        for i in 0..vec.len() {
+            vec[i] += 1;
+        }
+
+        vec.to_ocaml(cr)
+    }
+
+    fn rust_increment_floats_uniform_array(cr, ints: OCamlRef<OCamlUniformArray<OCamlFloat>>) -> OCaml<OCamlUniformArray<OCamlFloat>> {
+        let mut vec: Vec<f64> = ints.to_rust(cr);
+
+        for i in 0..vec.len() {
+            vec[i] += 1.;
+        }
+
+        vec.to_ocaml(cr)
+    }
+
+    fn rust_increment_floats_float_array(cr, ints: OCamlRef<OCamlFloatArray>) -> OCaml<OCamlFloatArray> {
+        let mut vec: Vec<f64> = ints.to_rust(cr);
+
+        for i in 0..vec.len() {
+            vec[i] += 1.;
         }
 
         vec.to_ocaml(cr)


### PR DESCRIPTION
This PR adds support for uniform arrays (i.e. arrays where elements are guaranteed to be boxed) and floatarrays (unboxed float arrays). Bumps the version of ocaml-sys so we can use `caml_sys_double_field` and the like.

This sidesteps the issue of supporting `array`s in general where it's pretty painful to dispatch to the correct type in Rust when seeing the double array tag since it's somewhat non-trivial to specialize traits based on whether the OCaml type is `OCamlFloat`/`f64`.